### PR TITLE
Fix this not bound when calling authenticateOidcSilent for silent renewal

### DIFF
--- a/src/store/create-store-module.ts
+++ b/src/store/create-store-module.ts
@@ -278,7 +278,7 @@ const createStoreModule = <T>(
                 this["unsetOidcAuth"]();
               }
               if (authenticateSilently) {
-                authenticateOidcSilent({ ignoreErrors: true }).catch(() => {});
+                authenticateOidcSilent.call(actions, { ignoreErrors: true }).catch(() => {});
               }
             } else {
               const authenticate = () => {
@@ -291,7 +291,7 @@ const createStoreModule = <T>(
               };
               // If silent signin is set up, try to authenticate silently before denying access
               if (authenticateSilently) {
-                authenticateOidcSilent({ ignoreErrors: true })
+                authenticateOidcSilent.call(actions, { ignoreErrors: true })
                   .then(() => {
                     oidcUserManager
                       .getUser()
@@ -398,7 +398,7 @@ const createStoreModule = <T>(
         });
         if (oidcSettings.automaticSilentRenew) {
           oidcUserManager.events.addAccessTokenExpiring(() => {
-            authenticateOidcSilent().catch((err) => {
+            authenticateOidcSilent.call(actions).catch((err) => {
               dispatchCustomErrorEvent(
                 "automaticSilentRenewError",
                 errorPayload("authenticateOidcSilent", err)


### PR DESCRIPTION
Fix silent renewal issue caused by `this` being `undefined` due to `authenticateOidcSilent` incorrectly called in some places.

Fixes #2 